### PR TITLE
Fix noarch in pipefunc-extra

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ name }}
@@ -46,10 +46,10 @@ outputs:
 
   - name: {{ name }}-extras
     build:
-      noarch: generic
+      noarch: python
     requirements:
       run:
-        - {{ pin_subpackage(name, max_pin="x.x.x") }}
+        - {{ pin_subpackage(name, exact=True) }}
         - adaptive
         - graphviz
         - graphviz-anywidget


### PR DESCRIPTION
Looked at https://github.com/bollwyvl/nbconvert-feedstock/blob/master/recipe/meta.yaml this time.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
